### PR TITLE
Add Forge circle with hex layout

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,3 +1,10 @@
+import Forge from './Forge'
+
 export default function App() {
-  return <h1>Hello Forge</h1>
+  return (
+    <div>
+      <h1>Hello Forge</h1>
+      <Forge />
+    </div>
+  )
 }

--- a/apps/web/src/Forge.css
+++ b/apps/web/src/Forge.css
@@ -1,0 +1,45 @@
+.forge {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  margin: 1rem auto;
+}
+
+.circle {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 60px;
+  height: 60px;
+  margin-top: -30px;
+  margin-left: -30px;
+  border-radius: 50%;
+  background: #555;
+  transition: background 0.3s;
+}
+
+.circle.lit {
+  background: gold;
+}
+
+.hex {
+  position: absolute;
+  width: 50px;
+  height: 50px;
+  background: #ccc;
+  clip-path: polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%);
+  border: none;
+  cursor: pointer;
+}
+
+.hex.filled {
+  background: #66c;
+}
+
+/* positions around circle */
+.hex:nth-child(2) { top: 0; left: 50%; transform: translate(-50%, -10%); }
+.hex:nth-child(3) { top: 25%; left: 90%; transform: translate(-50%, -50%); }
+.hex:nth-child(4) { top: 75%; left: 90%; transform: translate(-50%, -50%); }
+.hex:nth-child(5) { top: 100%; left: 50%; transform: translate(-50%, -90%); }
+.hex:nth-child(6) { top: 75%; left: 10%; transform: translate(-50%, -50%); }
+.hex:nth-child(7) { top: 25%; left: 10%; transform: translate(-50%, -50%); }

--- a/apps/web/src/Forge.test.tsx
+++ b/apps/web/src/Forge.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, it, expect } from 'vitest'
+import Forge from './Forge'
+
+describe('Forge', () => {
+  it('lights circle when all hexes filled', () => {
+    render(<Forge />)
+    const hexes = [0,1,2,3,4,5].map(i => screen.getByTestId(`hex-${i}`))
+    const circle = screen.getByTestId('circle')
+    hexes.forEach(hex => fireEvent.click(hex))
+    expect(circle.classList.contains('lit')).toBe(true)
+  })
+})

--- a/apps/web/src/Forge.tsx
+++ b/apps/web/src/Forge.tsx
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+import './Forge.css'
+
+export default function Forge() {
+  const [filled, setFilled] = useState(Array(6).fill(false))
+
+  const toggleSlot = (index: number) => {
+    setFilled(f => {
+      const copy = [...f]
+      copy[index] = !copy[index]
+      return copy
+    })
+  }
+
+  const allFilled = filled.every(Boolean)
+
+  return (
+    <div className="forge" data-testid="forge">
+      <div className={allFilled ? 'circle lit' : 'circle'} data-testid="circle" />
+      {filled.map((isFilled, idx) => (
+        <button
+          key={idx}
+          className={isFilled ? 'hex filled' : 'hex'}
+          data-testid={`hex-${idx}`}
+          onClick={() => toggleSlot(idx)}
+        />
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple Forge component with six hex slots around a central circle
- light up the circle when all hexes are filled
- include styles and tests
- render Forge component in the main App

## Testing
- `pnpm -r test` *(fails: vitest not found)*