### PR TITLE
Implement card creation and booster packs

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -8,7 +8,9 @@
   },
   "dependencies": {
     "react": "^18.0.0",
-    "react-dom": "^18.0.0"
+    "react-dom": "^18.0.0",
+    "zustand": "^4.5.2",
+    "zod": "^3.22.0"
   },
   "devDependencies": {
     "vite": "^5.0.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,10 +1,21 @@
 import Forge from './Forge'
+import CreateDistribute from './CreateDistribute'
+import { useState } from 'react'
 
 export default function App() {
+  const [tab, setTab] = useState<'forge'|'create'>('forge')
   return (
     <div>
-      <h1>Hello Forge</h1>
-      <Forge />
+      <button onClick={()=>setTab('forge')}>Forge</button>
+      <button onClick={()=>setTab('create')}>Create &amp; Distribute</button>
+      {tab === 'forge' ? (
+        <div>
+          <h1>Hello Forge</h1>
+          <Forge />
+        </div>
+      ) : (
+        <CreateDistribute />
+      )}
     </div>
   )
 }

--- a/apps/web/src/BoosterGenerator.tsx
+++ b/apps/web/src/BoosterGenerator.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+import { useDeckStore } from './store'
+import { generateBooster } from '../../packages/engine/src/booster'
+import type { BoosterPack } from '../../packages/schema/src'
+
+export default function BoosterGenerator() {
+  const cards = useDeckStore(s => s.cards)
+  const addBooster = useDeckStore(s => s.addBooster)
+  const [playerId, setPlayerId] = useState('')
+  const [size, setSize] = useState(6)
+  const [pack, setPack] = useState<BoosterPack | null>(null)
+
+  const handleGenerate = () => {
+    const newPack = generateBooster(cards, { playerId, size })
+    addBooster(newPack)
+    setPack(newPack)
+  }
+
+  return (
+    <div>
+      <h2>Generate Booster</h2>
+      <div>
+        <label>Player ID <input value={playerId} onChange={e=>setPlayerId(e.target.value)} /></label>
+        <label>Size <input type="number" value={size} onChange={e=>setSize(Number(e.target.value))} /></label>
+        <button onClick={handleGenerate}>Generate</button>
+      </div>
+      {pack && (
+        <div>
+          <h3>Booster Contents</h3>
+          <ul>
+            {pack.cards.map(c => (<li key={c.id}>{c.name}</li>))}
+          </ul>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/CardCreator.tsx
+++ b/apps/web/src/CardCreator.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react'
+import { randomUUID } from 'crypto'
+import {
+  EdgeIcon,
+  CardType,
+  Rarity,
+  HexCard as HexCardSchema
+} from '../../packages/schema/src'
+import { useDeckStore } from './store'
+
+export default function CardCreator() {
+  const addCard = useDeckStore(s => s.addCard)
+  const [name, setName] = useState('')
+  const [type, setType] = useState<CardType>('unit')
+  const [rarity, setRarity] = useState<Rarity>('common')
+  const [edges, setEdges] = useState<EdgeIcon[]>([
+    'attack',
+    'defense',
+    'skill',
+    'resource',
+    'link',
+    'element'
+  ])
+  const [tags, setTags] = useState('')
+  const [description, setDescription] = useState('')
+  const [error, setError] = useState('')
+
+  const updateEdge = (i: number, val: EdgeIcon) => {
+    const copy = [...edges]
+    copy[i] = val
+    setEdges(copy)
+  }
+
+  const handleSubmit = () => {
+    const card = {
+      id: randomUUID(),
+      name,
+      type,
+      rarity,
+      edges: edges as [EdgeIcon, EdgeIcon, EdgeIcon, EdgeIcon, EdgeIcon, EdgeIcon],
+      tags: tags.split(',').filter(t => t),
+      description
+    }
+    const parsed = HexCardSchema.safeParse(card)
+    if (!parsed.success) {
+      setError('Invalid card data')
+      return
+    }
+    addCard(parsed.data)
+    setName('')
+    setTags('')
+    setDescription('')
+  }
+
+  return (
+    <div>
+      <h2>New Card</h2>
+      {error && <div style={{color:'red'}}>{error}</div>}
+      <div>
+        <label>Name <input value={name} onChange={e=>setName(e.target.value)} /></label>
+      </div>
+      <div>
+        <label>Type
+          <select value={type} onChange={e=>setType(e.target.value as CardType)}>
+            {CardType.options.map(opt=>(
+              <option key={opt} value={opt}>{opt}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div>
+        <label>Rarity
+          <select value={rarity} onChange={e=>setRarity(e.target.value as Rarity)}>
+            {Rarity.options.map(r=>(<option key={r} value={r}>{r}</option>))}
+          </select>
+        </label>
+      </div>
+      <div>
+        Edges:
+        {edges.map((edge,i)=>(
+          <select key={i} value={edge} onChange={e=>updateEdge(i, e.target.value as EdgeIcon)}>
+            {EdgeIcon.options.map(o=>(<option key={o} value={o}>{o}</option>))}
+          </select>
+        ))}
+      </div>
+      <div>
+        <label>Tags <input value={tags} onChange={e=>setTags(e.target.value)} placeholder="comma separated" /></label>
+      </div>
+      <div>
+        <label>Description <input value={description} onChange={e=>setDescription(e.target.value)} /></label>
+      </div>
+      <button onClick={handleSubmit}>Save Card</button>
+      <pre>{JSON.stringify({name,type,rarity,edges,tags:tags.split(',')},null,2)}</pre>
+    </div>
+  )
+}

--- a/apps/web/src/CreateDistribute.tsx
+++ b/apps/web/src/CreateDistribute.tsx
@@ -1,0 +1,12 @@
+import CardCreator from './CardCreator'
+import BoosterGenerator from './BoosterGenerator'
+
+export default function CreateDistribute() {
+  return (
+    <div>
+      <h1>Create &amp; Distribute</h1>
+      <CardCreator />
+      <BoosterGenerator />
+    </div>
+  )
+}

--- a/apps/web/src/store.ts
+++ b/apps/web/src/store.ts
@@ -1,0 +1,23 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { HexCard } from '../../packages/schema/src'
+import type { BoosterPack } from '../../packages/schema/src'
+
+interface DeckState {
+  cards: HexCard[]
+  boosterHistory: BoosterPack[]
+  addCard: (card: HexCard) => void
+  addBooster: (pack: BoosterPack) => void
+}
+
+export const useDeckStore = create<DeckState>()(
+  persist(
+    (set, get) => ({
+      cards: [],
+      boosterHistory: [],
+      addCard: card => set(state => ({ cards: [...state.cards, card] })),
+      addBooster: pack => set(state => ({ boosterHistory: [...state.boosterHistory, pack] }))
+    }),
+    { name: 'deck-store' }
+  )
+)

--- a/docs/booster_example.json
+++ b/docs/booster_example.json
@@ -1,0 +1,15 @@
+{
+  "id": "123e4567-e89b-12d3-a456-426614174000",
+  "playerId": "player1",
+  "cards": [
+    {
+      "id": "card1",
+      "name": "Flame Adept",
+      "type": "unit",
+      "rarity": "common",
+      "edges": ["attack", "defense", "skill", "resource", "link", "element"],
+      "tags": ["fire"],
+      "description": "A novice of the flame arts"
+    }
+  ]
+}

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -11,5 +11,8 @@
   "devDependencies": {
     "typescript": "^5.0.0",
     "vitest": "^1.4.0"
+  },
+  "dependencies": {
+    "zod": "^3.22.0"
   }
 }

--- a/packages/engine/src/booster.test.ts
+++ b/packages/engine/src/booster.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+import { generateBooster, BoosterOptions } from './booster'
+import type { HexCard } from '../../schema/src'
+
+const deck: HexCard[] = Array.from({ length: 10 }).map((_, i) => ({
+  id: `c${i}`,
+  name: `Card ${i}`,
+  type: i % 2 === 0 ? 'unit' : 'spell',
+  rarity: i < 2 ? 'rare' : i < 5 ? 'uncommon' : 'common',
+  edges: ['attack','defense','skill','resource','link','element'],
+  tags: [],
+}))
+
+describe('generateBooster', () => {
+  it('creates pack with no duplicates', () => {
+    const options: BoosterOptions = { playerId: 'p1', size: 6 }
+    const pack = generateBooster(deck, options)
+    const ids = new Set(pack.cards.map(c => c.id))
+    expect(pack.cards).toHaveLength(6)
+    expect(ids.size).toBe(pack.cards.length)
+  })
+})

--- a/packages/engine/src/booster.ts
+++ b/packages/engine/src/booster.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from 'crypto'
+import type { BoosterPack, CardType, HexCard, Rarity } from '../../schema/src'
+
+export interface BoosterOptions {
+  playerId: string
+  size?: number
+  rarityDistribution?: Partial<Record<Rarity, number>>
+  allowedTypes?: CardType[]
+  tags?: string[]
+}
+
+export function generateBooster(
+  deck: HexCard[],
+  options: BoosterOptions
+): BoosterPack {
+  const size = options.size ?? 6
+  const distribution: Record<Rarity, number> = {
+    common: 0,
+    uncommon: 0,
+    rare: 0,
+    ...options.rarityDistribution
+  }
+  if (distribution.common + distribution.uncommon + distribution.rare === 0) {
+    distribution.common = size - 3
+    distribution.uncommon = 2
+    distribution.rare = 1
+  }
+
+  const filtered = deck.filter(card => {
+    if (options.allowedTypes && !options.allowedTypes.includes(card.type)) {
+      return false
+    }
+    if (options.tags && !options.tags.every(t => card.tags.includes(t))) {
+      return false
+    }
+    return true
+  })
+
+  const byRarity: Record<Rarity, HexCard[]> = {
+    common: filtered.filter(c => c.rarity === 'common'),
+    uncommon: filtered.filter(c => c.rarity === 'uncommon'),
+    rare: filtered.filter(c => c.rarity === 'rare')
+  }
+
+  const chosen: HexCard[] = []
+  for (const rarity of Object.keys(distribution) as Rarity[]) {
+    const count = distribution[rarity]
+    const pool = byRarity[rarity]
+    for (let i = 0; i < count && pool.length > 0; i++) {
+      const idx = Math.floor(Math.random() * pool.length)
+      chosen.push(pool.splice(idx, 1)[0])
+    }
+  }
+
+  while (chosen.length < size && filtered.length > 0) {
+    const idx = Math.floor(Math.random() * filtered.length)
+    const card = filtered.splice(idx, 1)[0]
+    if (!chosen.includes(card)) chosen.push(card)
+  }
+
+  return {
+    id: randomUUID(),
+    playerId: options.playerId,
+    cards: chosen.slice(0, size)
+  }
+}
+
+export type { BoosterPack }

--- a/packages/engine/src/index.ts
+++ b/packages/engine/src/index.ts
@@ -29,3 +29,5 @@ export function forgeCharacter(cards: HexCard[], name: string): Character {
     cardIds: cards.map(c => c.id)
   }
 }
+
+export { generateBooster } from './booster'

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "typescript": "^5.0.0"
+  },
+  "dependencies": {
+    "zod": "^3.22.0"
   }
 }

--- a/packages/schema/src/card.test.ts
+++ b/packages/schema/src/card.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { HexCard } from './index'
+
+const valid = {
+  id: '11111111-1111-1111-1111-111111111111',
+  name: 'Test',
+  type: 'unit',
+  rarity: 'common',
+  edges: ['attack','defense','skill','resource','link','element'],
+  tags: []
+}
+
+describe('HexCard schema', () => {
+  it('accepts valid card', () => {
+    expect(HexCard.parse(valid).name).toBe('Test')
+  })
+
+  it('rejects invalid card', () => {
+    const bad = { ...valid, edges: ['attack'] }
+    expect(() => HexCard.parse(bad as any)).toThrow()
+  })
+})

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,2 +1,52 @@
-// TODO: add Zod models per spec
+import { z } from 'zod'
+
+export const EdgeIcon = z.enum([
+  'attack',
+  'defense',
+  'skill',
+  'resource',
+  'link',
+  'element'
+])
+
+export const CardType = z.enum([
+  'unit',
+  'hero',
+  'spell',
+  'relic',
+  'structure'
+])
+
+export const Rarity = z.enum(['common', 'uncommon', 'rare'])
+
+export const HexCard = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  type: CardType,
+  rarity: Rarity,
+  edges: z.tuple([
+    EdgeIcon,
+    EdgeIcon,
+    EdgeIcon,
+    EdgeIcon,
+    EdgeIcon,
+    EdgeIcon
+  ]),
+  tags: z.array(z.string()).default([]),
+  description: z.string().optional(),
+  image: z.string().url().optional()
+})
+
+export const BoosterPack = z.object({
+  id: z.string().uuid(),
+  playerId: z.string(),
+  cards: z.array(HexCard)
+})
+
+export type EdgeIcon = z.infer<typeof EdgeIcon>
+export type CardType = z.infer<typeof CardType>
+export type Rarity = z.infer<typeof Rarity>
+export type HexCard = z.infer<typeof HexCard>
+export type BoosterPack = z.infer<typeof BoosterPack>
+
 export {}


### PR DESCRIPTION
## Summary
- add Zod card and booster schemas
- implement booster pack generator in engine
- create card creator & booster generator UI with Zustand store
- provide example booster JSON output
- include unit tests for card schema and booster generator

## Testing
- `pnpm test` *(fails: vitest not found because dependencies are not installed)*