### PR TITLE
Add map and ship builder scaffolding

### DIFF
--- a/apps/web/src/MapEditor.tsx
+++ b/apps/web/src/MapEditor.tsx
@@ -1,0 +1,3 @@
+export default function MapEditor() {
+  return <div>Map Editor Placeholder</div>
+}

--- a/apps/web/src/SpaceshipBuilder.tsx
+++ b/apps/web/src/SpaceshipBuilder.tsx
@@ -1,0 +1,3 @@
+export default function SpaceshipBuilder() {
+  return <div>Spaceship Builder Placeholder</div>
+}

--- a/packages/engine/src/map.test.ts
+++ b/packages/engine/src/map.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { generateRandomMap } from './map'
+import type { TerrainType } from '../../schema/src'
+
+const grass: TerrainType = {
+  id: 't1',
+  name: 'Grass',
+  movementCost: 1,
+  theme: 'fantasy'
+}
+
+describe('generateRandomMap', () => {
+  it('creates grid with given size', () => {
+    const grid = generateRandomMap({
+      width: 2,
+      height: 2,
+      terrains: [{ type: grass, weight: 1 }]
+    })
+    expect(grid).toHaveLength(2)
+    expect(grid[0]).toHaveLength(2)
+    expect(grid[1][1].terrain.name).toBe('Grass')
+  })
+})

--- a/packages/engine/src/map.ts
+++ b/packages/engine/src/map.ts
@@ -1,0 +1,47 @@
+import type { TerrainType, Theme } from '../../schema/src'
+
+export interface HexTile {
+  q: number
+  r: number
+  terrain: TerrainType
+  elevation?: number
+  tags?: string[]
+}
+
+export interface TerrainDistribution {
+  type: TerrainType
+  weight: number
+}
+
+export interface RandomMapOptions {
+  width: number
+  height: number
+  terrains: TerrainDistribution[]
+  theme?: Theme
+}
+
+export function generateRandomMap(opts: RandomMapOptions): HexTile[][] {
+  const pool = opts.theme
+    ? opts.terrains.filter(t => t.type.theme === opts.theme)
+    : opts.terrains
+  const total = pool.reduce((sum, t) => sum + t.weight, 0)
+  const choose = (): TerrainType => {
+    const r = Math.random() * total
+    let acc = 0
+    for (const item of pool) {
+      acc += item.weight
+      if (r <= acc) return item.type
+    }
+    return pool[pool.length - 1].type
+  }
+
+  const map: HexTile[][] = []
+  for (let y = 0; y < opts.height; y++) {
+    const row: HexTile[] = []
+    for (let x = 0; x < opts.width; x++) {
+      row.push({ q: x, r: y, terrain: choose() })
+    }
+    map.push(row)
+  }
+  return map
+}

--- a/packages/engine/src/ship.test.ts
+++ b/packages/engine/src/ship.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest'
+import { aggregateShipStats } from './ship'
+import type { ShipDefinition } from '../../schema/src'
+
+const ship: ShipDefinition = {
+  id: 's1',
+  name: 'Test',
+  parts: [
+    { id: 'p1', name: 'Hull', type: 'hull', stats: { defense: 3 } },
+    { id: 'p2', name: 'Engine', type: 'engine', stats: { speed: 5 } },
+    { id: 'p3', name: 'Gun', type: 'weapon', stats: { attack: 2 } }
+  ]
+}
+
+describe('aggregateShipStats', () => {
+  it('sums stats from parts', () => {
+    const stats = aggregateShipStats(ship)
+    expect(stats.speed).toBe(5)
+    expect(stats.defense).toBe(3)
+    expect(stats.attack).toBe(2)
+    expect(stats.cargo).toBe(0)
+  })
+})

--- a/packages/engine/src/ship.ts
+++ b/packages/engine/src/ship.ts
@@ -1,0 +1,21 @@
+import type { ShipDefinition } from '../../schema/src'
+
+export interface ShipStats {
+  speed: number
+  defense: number
+  cargo: number
+  attack: number
+}
+
+const empty: ShipStats = { speed: 0, defense: 0, cargo: 0, attack: 0 }
+
+export function aggregateShipStats(ship: ShipDefinition): ShipStats {
+  return ship.parts.reduce((acc, part) => {
+    const stats = part.stats
+    acc.speed += stats.speed ?? 0
+    acc.defense += stats.defense ?? 0
+    acc.cargo += stats.cargo ?? 0
+    acc.attack += stats.attack ?? 0
+    return acc
+  }, { ...empty })
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -43,10 +43,63 @@ export const BoosterPack = z.object({
   cards: z.array(HexCard)
 })
 
+export const Theme = z.enum(['fantasy', 'sci-fi'])
+
+export const TerrainType = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  movementCost: z.number().min(0),
+  resourceOutput: z.number().min(0).optional(),
+  color: z.string().optional(),
+  texture: z.string().optional(),
+  theme: Theme
+})
+
+export const StructureType = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  attributes: z.record(z.any()).default({}),
+  theme: Theme
+})
+
+export const ShipPartType = z.enum([
+  'hull',
+  'engine',
+  'weapon',
+  'cargo',
+  'utility'
+])
+
+export const ShipPart = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  type: ShipPartType,
+  stats: z.object({
+    speed: z.number().optional(),
+    defense: z.number().optional(),
+    cargo: z.number().optional(),
+    attack: z.number().optional()
+  }).default({}),
+  skin: z.string().optional(),
+  theme: Theme.optional()
+})
+
+export const ShipDefinition = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  parts: z.array(ShipPart)
+})
+
 export type EdgeIcon = z.infer<typeof EdgeIcon>
 export type CardType = z.infer<typeof CardType>
 export type Rarity = z.infer<typeof Rarity>
 export type HexCard = z.infer<typeof HexCard>
 export type BoosterPack = z.infer<typeof BoosterPack>
+export type Theme = z.infer<typeof Theme>
+export type TerrainType = z.infer<typeof TerrainType>
+export type StructureType = z.infer<typeof StructureType>
+export type ShipPartType = z.infer<typeof ShipPartType>
+export type ShipPart = z.infer<typeof ShipPart>
+export type ShipDefinition = z.infer<typeof ShipDefinition>
 
 export {}


### PR DESCRIPTION
## Summary
- define world & ship schemas with Zod
- add random map generator and ship stat aggregator logic
- create unit tests for new modules
- stub MapEditor and SpaceshipBuilder components

## Testing
- `pnpm test` *(fails: vitest not installed)*