### PR TITLE
Add CharacterForge module

### DIFF
--- a/apps/web/src/forge/CharacterForge.tsx
+++ b/apps/web/src/forge/CharacterForge.tsx
@@ -1,0 +1,119 @@
+import { useCharacterForgeStore } from './characterForgeStore'
+import type { HexCard } from './forgeSchema'
+import type { Slot } from './forgeLogic'
+import { ForgedHeroSchema } from './forgeSchema'
+
+interface CharacterForgeProps {
+  availableCards: HexCard[]
+  onForge?: (hero: unknown) => void
+}
+
+const slotPositions: Record<Slot, string> = {
+  topLeft: 'top-2 left-1/4',
+  top: 'top-0 left-1/2 -translate-x-1/2',
+  topRight: 'top-2 right-1/4',
+  bottomLeft: 'bottom-2 left-1/4',
+  bottom: 'bottom-0 left-1/2 -translate-x-1/2',
+  bottomRight: 'bottom-2 right-1/4'
+}
+
+function HexSlot({ slot, card, onDrop }: { slot: Slot; card: HexCard | null; onDrop: (slot: Slot, card: HexCard) => void }) {
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    const data = e.dataTransfer.getData('text')
+    if (!data) return
+    const card = JSON.parse(data) as HexCard
+    onDrop(slot, card)
+  }
+  return (
+    <div
+      className={`absolute w-16 h-16 flex items-center justify-center border rounded-md bg-gray-200 ${slotPositions[slot]}`}
+      style={{ clipPath: 'polygon(25% 0%, 75% 0%, 100% 50%, 75% 100%, 25% 100%, 0% 50%)' }}
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={handleDrop}
+    >
+      {card && <span className="text-xs text-center">{card.name}</span>}
+    </div>
+  )
+}
+
+function CardPreview({ card }: { card: HexCard }) {
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => {
+    e.dataTransfer.setData('text', JSON.stringify(card))
+  }
+  return (
+    <div draggable onDragStart={handleDragStart} className="border p-2 m-1 bg-white text-xs shadow cursor-move">
+      {card.name}
+    </div>
+  )
+}
+
+function StatPreview() {
+  const stats = useCharacterForgeStore((s) => s.finalStats)
+  const label = useCharacterForgeStore((s) => s.classLabel)
+  return (
+    <div className="text-center mt-4">
+      <p>STR {stats.strength}</p>
+      <p>AGI {stats.agility}</p>
+      <p>INT {stats.intellect}</p>
+      <p className="font-bold">{label}</p>
+    </div>
+  )
+}
+
+function ForgeButton({ onForge }: { onForge: () => void }) {
+  const equipped = useCharacterForgeStore((s) => s.equippedCards)
+  const allFilled = Object.values(equipped).every(Boolean)
+  return (
+    <button
+      disabled={!allFilled}
+      onClick={onForge}
+      className={`mt-4 px-4 py-2 rounded text-white ${allFilled ? 'bg-yellow-500 animate-pulse' : 'bg-gray-400'}`}
+    >
+      FORGE HERO
+    </button>
+  )
+}
+
+export default function CharacterForge({ availableCards, onForge }: CharacterForgeProps) {
+  const name = useCharacterForgeStore((s) => s.name)
+  const setName = useCharacterForgeStore((s) => s.setName)
+  const equipped = useCharacterForgeStore((s) => s.equippedCards)
+  const setCard = useCharacterForgeStore((s) => s.setCard)
+  const finalStats = useCharacterForgeStore((s) => s.finalStats)
+  const classLabel = useCharacterForgeStore((s) => s.classLabel)
+
+  const handleForge = () => {
+    const hero = {
+      name,
+      equippedCards: equipped,
+      finalStats,
+      classLabel
+    }
+    const parsed = ForgedHeroSchema.safeParse(hero)
+    if (parsed.success) {
+      onForge?.(parsed.data)
+    } else {
+      alert('Hero invalid: ' + parsed.error.message)
+    }
+  }
+
+  return (
+    <div className="p-4">
+      <input className="border p-1 mb-2" value={name} onChange={(e) => setName(e.target.value)} placeholder="Hero name" />
+      <div className="relative w-64 h-64 mx-auto">
+        {Object.entries(equipped).map(([slot, card]) => (
+          <HexSlot key={slot} slot={slot as Slot} card={card} onDrop={setCard} />
+        ))}
+        <div className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-20 h-20 rounded-full bg-gray-700" />
+      </div>
+      <StatPreview />
+      <ForgeButton onForge={handleForge} />
+      <div className="flex flex-wrap mt-4">
+        {availableCards.map((c) => (
+          <CardPreview key={c.id} card={c} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/forge/characterForgeStore.ts
+++ b/apps/web/src/forge/characterForgeStore.ts
@@ -1,0 +1,44 @@
+import { create } from 'zustand'
+import type { HexCard } from './forgeSchema'
+import type { Slot, Equipped } from './forgeLogic'
+import { computeStatsAndClass } from './forgeLogic'
+
+interface ForgeState {
+  name: string
+  equippedCards: Equipped
+  finalStats: { strength: number; agility: number; intellect: number }
+  classLabel: string
+  setName: (name: string) => void
+  setCard: (slot: Slot, card: HexCard | null) => void
+  reset: () => void
+}
+
+const emptyEquip: Equipped = {
+  topLeft: null,
+  top: null,
+  topRight: null,
+  bottomLeft: null,
+  bottom: null,
+  bottomRight: null
+}
+
+export const useCharacterForgeStore = create<ForgeState>((set) => ({
+  name: '',
+  equippedCards: emptyEquip,
+  finalStats: { strength: 0, agility: 0, intellect: 0 },
+  classLabel: 'Adventurer',
+  setName: (name) => set({ name }),
+  setCard: (slot, card) =>
+    set((state) => {
+      const updated: Equipped = { ...state.equippedCards, [slot]: card }
+      const { stats, classLabel } = computeStatsAndClass(updated)
+      return { equippedCards: updated, finalStats: stats, classLabel }
+    }),
+  reset: () =>
+    set({
+      name: '',
+      equippedCards: emptyEquip,
+      finalStats: { strength: 0, agility: 0, intellect: 0 },
+      classLabel: 'Adventurer'
+    })
+}))

--- a/apps/web/src/forge/forgeLogic.test.ts
+++ b/apps/web/src/forge/forgeLogic.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { computeStatsAndClass, Equipped, Slot } from './forgeLogic'
+import type { HexCard } from './forgeSchema'
+
+const fireCard: HexCard = {
+  id: '1',
+  name: 'Flame',
+  type: 'element',
+  attributes: { strength: 1, element: 'fire' }
+}
+
+const iceCard: HexCard = {
+  id: '2',
+  name: 'Ice',
+  type: 'element',
+  attributes: { strength: 1, element: 'ice' }
+}
+
+const baseEquip: Equipped = {
+  topLeft: fireCard,
+  top: fireCard,
+  topRight: fireCard,
+  bottomLeft: iceCard,
+  bottom: iceCard,
+  bottomRight: iceCard
+}
+
+describe('computeStatsAndClass', () => {
+  it('adds stats and detects elemental class', () => {
+    const result = computeStatsAndClass(baseEquip)
+    expect(result.stats.strength).toBe(6)
+    expect(result.classLabel).toBe('Fire Mage')
+  })
+})

--- a/apps/web/src/forge/forgeLogic.ts
+++ b/apps/web/src/forge/forgeLogic.ts
@@ -1,0 +1,39 @@
+import type { HexCard } from './forgeSchema'
+
+export type Slot = 'topLeft' | 'top' | 'topRight' | 'bottomLeft' | 'bottom' | 'bottomRight'
+export type Equipped = Record<Slot, HexCard | null>
+
+function capitalize(s: string) {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export function computeStatsAndClass(equipped: Equipped) {
+  let strength = 0
+  let agility = 0
+  let intellect = 0
+  const elements: Record<string, number> = {}
+
+  Object.values(equipped).forEach(card => {
+    if (!card) return
+    const attr = card.attributes
+    strength += attr.strength ?? 0
+    agility += attr.agility ?? 0
+    intellect += attr.intellect ?? 0
+    if (attr.element) {
+      elements[attr.element] = (elements[attr.element] ?? 0) + 1
+    }
+  })
+
+  let classLabel = 'Adventurer'
+  for (const [el, count] of Object.entries(elements)) {
+    if (count >= 3) {
+      classLabel = `${capitalize(el)} Mage`
+      break
+    }
+  }
+
+  return {
+    stats: { strength, agility, intellect },
+    classLabel
+  }
+}

--- a/apps/web/src/forge/forgeSchema.ts
+++ b/apps/web/src/forge/forgeSchema.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod'
+
+export const HexCardSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.enum(['weapon', 'armor', 'element', 'psyche', 'artifact']),
+  attributes: z.object({
+    strength: z.number().optional(),
+    agility: z.number().optional(),
+    intellect: z.number().optional(),
+    element: z.enum(['fire', 'ice', 'lightning', 'earth']).optional(),
+    ability: z.string().optional()
+  })
+})
+
+export type HexCard = z.infer<typeof HexCardSchema>
+
+export const EquippedSlots = z.object({
+  topLeft: z.union([HexCardSchema, z.null()]),
+  top: z.union([HexCardSchema, z.null()]),
+  topRight: z.union([HexCardSchema, z.null()]),
+  bottomLeft: z.union([HexCardSchema, z.null()]),
+  bottom: z.union([HexCardSchema, z.null()]),
+  bottomRight: z.union([HexCardSchema, z.null()])
+})
+
+export const ForgedHeroSchema = z.object({
+  name: z.string(),
+  equippedCards: EquippedSlots.refine(
+    s => Object.values(s).every(Boolean),
+    { message: 'All sockets must be filled' }
+  ),
+  finalStats: z.object({
+    strength: z.number(),
+    agility: z.number(),
+    intellect: z.number()
+  }),
+  classLabel: z.string()
+})
+
+export type ForgedHero = z.infer<typeof ForgedHeroSchema>


### PR DESCRIPTION
## Summary
- implement forge Zod schemas for hero and cards
- add forge logic to aggregate stats and determine class
- create Zustand store for character forging
- build CharacterForge React component with drag/drop
- include basic unit test for stat computation

## Testing
- `pnpm test` *(fails: vitest not installed)*