### PR TITLE
Add map generation service and schemas

### DIFF
--- a/packages/engine/src/mapGen.test.ts
+++ b/packages/engine/src/mapGen.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest'
+import { generateMap } from './mapGen'
+import { Terrain } from '../../schema/src'
+
+const weights = { plains: 0.6, forest: 0.4 } as const
+
+function countBy<T extends string>(tiles: { terrain: T }[]): Record<T, number> {
+  const counts: Record<string, number> = {}
+  for (const t of tiles) counts[t.terrain] = (counts[t.terrain] || 0) + 1
+  return counts as Record<T, number>
+}
+
+describe('generateMap', () => {
+  it('creates the correct number of tiles', () => {
+    const tiles = generateMap({ width: 5, height: 4, terrainWeights: weights, seed: 1, theme: 'fantasy' })
+    expect(tiles).toHaveLength(20)
+  })
+
+  it('approximates terrain distribution', () => {
+    const tiles = generateMap({ width: 50, height: 50, terrainWeights: weights, seed: 42, theme: 'fantasy' })
+    const counts = countBy(tiles)
+    const total = tiles.length
+    for (const key of Object.keys(weights) as Array<keyof typeof weights>) {
+      const expected = weights[key] * total
+      const diff = Math.abs(counts[key] - expected) / expected
+      expect(diff).toBeLessThan(0.05)
+    }
+  })
+})

--- a/packages/engine/src/mapGen.ts
+++ b/packages/engine/src/mapGen.ts
@@ -1,0 +1,47 @@
+import { MapTile, Terrain } from '../../schema/src'
+
+export interface MapGenOptions {
+  width: number
+  height: number
+  terrainWeights: Partial<Record<Terrain, number>>
+  seed?: number
+  roughness?: number
+  theme: 'fantasy' | 'sci-fi'
+}
+
+function mulberry32(a: number): () => number {
+  return function() {
+    let t = a += 0x6D2B79F5
+    t = Math.imul(t ^ t >>> 15, t | 1)
+    t ^= t + Math.imul(t ^ t >>> 7, t | 61)
+    return ((t ^ t >>> 14) >>> 0) / 4294967296
+  }
+}
+
+export function generateMap(options: MapGenOptions): MapTile[] {
+  const {
+    width,
+    height,
+    terrainWeights,
+    seed = Date.now(),
+  } = options
+  const rng = mulberry32(seed)
+  const entries = Object.entries(terrainWeights) as [Terrain, number][]
+  const total = entries.reduce((s, [, w]) => s + w, 0)
+  const pick = () => {
+    const r = rng() * total
+    let acc = 0
+    for (const [terrain, weight] of entries) {
+      acc += weight
+      if (r <= acc) return terrain
+    }
+    return entries[entries.length - 1][0]
+  }
+  const tiles: MapTile[] = []
+  for (let r = 0; r < height; r++) {
+    for (let q = 0; q < width; q++) {
+      tiles.push(MapTile.parse({ q, r, terrain: pick() }))
+    }
+  }
+  return tiles
+}

--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -45,6 +45,16 @@ export const BoosterPack = z.object({
 
 export const Theme = z.enum(['fantasy', 'sci-fi'])
 
+export const Terrain = z.enum([
+  'plains',
+  'forest',
+  'mountain',
+  'water',
+  'desert',
+  'swamp',
+  'city'
+])
+
 export const TerrainType = z.object({
   id: z.string().uuid(),
   name: z.string(),
@@ -90,6 +100,19 @@ export const ShipDefinition = z.object({
   parts: z.array(ShipPart)
 })
 
+export const MapTile = z.object({
+  q: z.number().int(),
+  r: z.number().int(),
+  terrain: Terrain,
+  occupantId: z.string().uuid().optional()
+})
+
+export const NetMessage = z.object({
+  type: z.string(),
+  payload: z.any(),
+  seq: z.number().int()
+})
+
 export type EdgeIcon = z.infer<typeof EdgeIcon>
 export type CardType = z.infer<typeof CardType>
 export type Rarity = z.infer<typeof Rarity>
@@ -101,5 +124,23 @@ export type StructureType = z.infer<typeof StructureType>
 export type ShipPartType = z.infer<typeof ShipPartType>
 export type ShipPart = z.infer<typeof ShipPart>
 export type ShipDefinition = z.infer<typeof ShipDefinition>
+export type Terrain = z.infer<typeof Terrain>
+export type MapTile = z.infer<typeof MapTile>
+export type NetMessage = z.infer<typeof NetMessage>
 
-export {}
+export {
+  EdgeIcon,
+  CardType,
+  Rarity,
+  HexCard,
+  BoosterPack,
+  Theme,
+  Terrain,
+  TerrainType,
+  StructureType,
+  ShipPartType,
+  ShipPart,
+  ShipDefinition,
+  MapTile,
+  NetMessage
+}


### PR DESCRIPTION
## Summary
- define Terrain enum, MapTile and NetMessage schemas
- export schema members
- add procedural map generator with seeded RNG
- test generator distribution and count

## Testing
- `pnpm -r test` *(fails: vitest not found)*